### PR TITLE
Draft for changing IPackage

### DIFF
--- a/src/AppInstallerCLICore/ConfigurationWingetDscModuleUnitValidation.cpp
+++ b/src/AppInstallerCLICore/ConfigurationWingetDscModuleUnitValidation.cpp
@@ -358,7 +358,8 @@ namespace AppInstaller::CLI::Configuration
                    {
                        if (!package.Version.empty())
                        {
-                           auto versionKeys = searchResult.Matches.at(0).Package->GetAvailableVersionKeys();
+                           std::shared_ptr<Repository::IPackage> availablePackage = searchResult.Matches.at(0).Package->GetAvailable().at(0);
+                           auto versionKeys = availablePackage->GetVersionKeys();
                            bool foundVersion = false;
                            for (auto const& versionKey : versionKeys)
                            {

--- a/src/AppInstallerCLICore/ExecutionContextData.h
+++ b/src/AppInstallerCLICore/ExecutionContextData.h
@@ -103,7 +103,7 @@ namespace AppInstaller::CLI::Execution
         template <>
         struct DataMapping<Data::Package>
         {
-            using value_t = std::shared_ptr<Repository::IPackage>;
+            using value_t = std::shared_ptr<Repository::ICompositePackage>;
         };
 
         template <>

--- a/src/AppInstallerCLICore/Workflows/CompletionFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/CompletionFlow.cpp
@@ -70,11 +70,14 @@ namespace AppInstaller::CLI::Workflow
         const std::string& word = context.Get<Data::CompletionData>().Word();
         auto stream = context.Reporter.Completion();
 
-        for (const auto& vc : context.Get<Execution::Data::Package>()->GetAvailableVersionKeys())
+        for (const auto& ap : context.Get<Execution::Data::Package>()->GetAvailable())
         {
-            if (word.empty() || Utility::ICUCaseInsensitiveStartsWith(vc.Version, word))
+            for (const auto& vc : ap->GetVersionKeys())
             {
-                OutputCompletionString(stream, vc.Version);
+                if (word.empty() || Utility::ICUCaseInsensitiveStartsWith(vc.Version, word))
+                {
+                    OutputCompletionString(stream, vc.Version);
+                }
             }
         }
     }
@@ -86,12 +89,15 @@ namespace AppInstaller::CLI::Workflow
 
         std::vector<std::string> channels;
 
-        for (const auto& vc : context.Get<Execution::Data::Package>()->GetAvailableVersionKeys())
+        for (const auto& ap : context.Get<Execution::Data::Package>()->GetAvailable())
         {
-            if ((word.empty() || Utility::ICUCaseInsensitiveStartsWith(vc.Channel, word)) &&
-                std::find(channels.begin(), channels.end(), vc.Channel) == channels.end())
+            for (const auto& vc : ap->GetVersionKeys())
             {
-                channels.emplace_back(vc.Channel);
+                if ((word.empty() || Utility::ICUCaseInsensitiveStartsWith(vc.Channel, word)) &&
+                    std::find(channels.begin(), channels.end(), vc.Channel) == channels.end())
+                {
+                    channels.emplace_back(vc.Channel);
+                }
             }
         }
 

--- a/src/AppInstallerCLICore/Workflows/DependencyNodeProcessor.cpp
+++ b/src/AppInstallerCLICore/Workflows/DependencyNodeProcessor.cpp
@@ -42,7 +42,7 @@ namespace AppInstaller::CLI::Workflow
         const auto& match = matches.at(0);
         const auto& package = match.Package;
         auto packageId = package->GetProperty(PackageProperty::Id);
-        m_nodePackageInstalledVersion = package->GetInstalled()->GetLatestVersion();
+        m_nodePackageInstalledVersion = GetInstalledVersion(package);
         std::shared_ptr<IPackageVersionCollection> availableVersions = GetAvailableVersionsForInstalledVersion(package);
 
         if (m_context.Args.Contains(Execution::Args::Type::Force))

--- a/src/AppInstallerCLICore/Workflows/ImportExportFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ImportExportFlow.cpp
@@ -103,7 +103,7 @@ namespace AppInstaller::CLI::Workflow
         auto& exportedSources = exportedPackages.Sources;
         for (const auto& packageMatch : searchResult.Matches)
         {
-            auto installedPackageVersion = packageMatch.Package->GetInstalled()->GetLatestVersion();
+            auto installedPackageVersion = GetInstalledVersion(packageMatch.Package);
             auto version = installedPackageVersion->GetProperty(PackageVersionProperty::Version);
             auto channel = installedPackageVersion->GetProperty(PackageVersionProperty::Channel);
 

--- a/src/AppInstallerCLICore/Workflows/PinFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PinFlow.cpp
@@ -6,6 +6,7 @@
 #include "TableOutput.h"
 #include <winget/PinningData.h>
 #include <winget/RepositorySearch.h>
+#include <winget/PackageVersionSelection.h>
 
 using namespace AppInstaller::Repository;
 
@@ -38,7 +39,7 @@ namespace AppInstaller::CLI::Workflow
 
             if (context.Args.Contains(Execution::Args::Type::PinInstalled))
             {
-                auto installedVersion = package->GetInstalledVersion();
+                auto installedVersion = GetInstalledVersion(package);
                 if (installedVersion)
                 {
                     pinKeys.emplace(Pinning::PinKey::GetPinKeyForInstalled(installedVersion->GetProperty(PackageVersionProperty::Id)));
@@ -46,13 +47,12 @@ namespace AppInstaller::CLI::Workflow
             }
             else
             {
-                auto packageVersionKeys = package->GetAvailableVersionKeys();
-                for (const auto& versionKey : packageVersionKeys)
+                auto availablePackages = package->GetAvailable();
+                for (const auto& availablePackage : availablePackages)
                 {
-                    auto availableVersion = package->GetAvailableVersion(versionKey);
                     pinKeys.emplace(
-                        availableVersion->GetProperty(PackageVersionProperty::Id).get(),
-                        availableVersion->GetProperty(PackageVersionProperty::SourceIdentifier).get());
+                        availablePackage->GetProperty(PackageProperty::Id).get(),
+                        availablePackage->GetSource().GetIdentifier());
                 }
             }
 
@@ -140,7 +140,7 @@ namespace AppInstaller::CLI::Workflow
                 }
                 else
                 {
-                    auto availableVersion = package->GetAvailableVersion({ pinKey.SourceId, "", "" });
+                    auto availableVersion = GetAvailableVersionsForInstalledVersion(package, nullptr)->GetVersion({ pinKey.SourceId, "", "" });
                     if (availableVersion)
                     {
                         packageNameToReport = availableVersion->GetProperty(PackageVersionProperty::Name);
@@ -198,8 +198,6 @@ namespace AppInstaller::CLI::Workflow
         // Note that if a source was specified in the command line,
         // that will be the only one we get version keys from.
         // So, we remove pins from all sources unless one was provided.
-        auto packageVersionKeys = package->GetAvailableVersionKeys();
-
         for (const auto& pin : pins)
         {
             AICLI_LOG(CLI, Info, << "Removing Pin " << pin.GetKey().ToString());
@@ -255,15 +253,19 @@ namespace AppInstaller::CLI::Workflow
                 else
                 {
                     // This ensures we get the info from the right source if it exists on multiple
-                    auto availableVersion = match.Package->GetAvailableVersion({ pinKey.SourceId, "", "" });
-                    if (availableVersion)
+                    auto availablePackage = GetAvailablePackageFromSource(match.Package, pinKey.SourceId);
+                    if (availablePackage)
                     {
-                        packageName = availableVersion->GetProperty(PackageVersionProperty::Name);
-                        sourceName = availableVersion->GetProperty(PackageVersionProperty::SourceName);
+                        auto availableVersion = availablePackage->GetLatestVersion();
+                        if (availableVersion)
+                        {
+                            packageName = availableVersion->GetProperty(PackageVersionProperty::Name);
+                            sourceName = availableVersion->GetProperty(PackageVersionProperty::SourceName);
+                        }
                     }
                 }
 
-                auto installedVersion = match.Package->GetInstalledVersion();
+                auto installedVersion = GetInstalledVersion(match.Package);
                 if (installedVersion)
                 {
                     packageName = installedVersion->GetProperty(PackageVersionProperty::Name);

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -11,6 +11,7 @@
 #include <winget/Pin.h>
 #include <winget/PinningData.h>
 #include <winget/Runtime.h>
+#include <winget/PackageVersionSelection.h>
 
 using namespace std::string_literals;
 using namespace AppInstaller::Utility::literals;
@@ -628,7 +629,7 @@ namespace AppInstaller::CLI::Workflow
 
         for (size_t i = 0; i < searchResult.Matches.size(); ++i)
         {
-            auto latestVersion = searchResult.Matches[i].Package->GetLatestAvailableVersion();
+            auto latestVersion = GetAvailableVersionsForInstalledVersion(searchResult.Matches[i].Package, nullptr)->GetLatestVersion();
 
             table.OutputLine({
                 latestVersion->GetProperty(PackageVersionProperty::Name),
@@ -739,10 +740,10 @@ namespace AppInstaller::CLI::Workflow
             auto package = searchResult.Matches[i].Package;
 
             std::string sourceName;
-            auto latest = package->GetLatestAvailableVersion();
-            if (latest)
+            auto available = package->GetAvailable();
+            if (!available.empty())
             {
-                auto source = latest->GetSource();
+                auto source = available[0]->GetSource();
                 if (source)
                 {
                     sourceName = source.GetDetails().Name;
@@ -799,13 +800,14 @@ namespace AppInstaller::CLI::Workflow
 
         for (const auto& match : searchResult.Matches)
         {
-            auto installedVersion = match.Package->GetInstalledVersion();
+            auto installedVersion = GetInstalledVersion(match.Package);
 
             if (installedVersion)
             {
                 auto evaluator = pinningData.CreatePinStateEvaluator(pinBehavior, installedVersion);
+                auto availableVersions = GetAvailableVersionsForInstalledVersion(match.Package, installedVersion);
 
-                auto latestVersion = evaluator.GetLatestAvailableVersionForPins(match.Package);
+                auto latestVersion = evaluator.GetLatestAvailableVersionForPins(availableVersions);
                 bool updateAvailable = evaluator.IsUpdate(latestVersion);
                 bool updateIsPinned = false;
 
@@ -819,7 +821,7 @@ namespace AppInstaller::CLI::Workflow
                 if (m_onlyShowUpgrades && !updateAvailable)
                 {
                     // Reuse the evaluator to check if there is an update outside of the pinning
-                    auto unpinnedLatestVersion = match.Package->GetLatestAvailableVersion();
+                    auto unpinnedLatestVersion = availableVersions->GetLatestVersion();
                     bool updateAvailableWithoutPins = evaluator.IsUpdate(unpinnedLatestVersion);
 
                     if (updateAvailableWithoutPins)
@@ -995,7 +997,7 @@ namespace AppInstaller::CLI::Workflow
                 AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_MULTIPLE_APPLICATIONS_FOUND);
             }
 
-            std::shared_ptr<IPackage> package = searchResult.Matches.at(0).Package;
+            std::shared_ptr<ICompositePackage> package = searchResult.Matches.at(0).Package;
             Logging::Telemetry().LogAppFound(package->GetProperty(PackageProperty::Name), package->GetProperty(PackageProperty::Id));
 
             context.Add<Execution::Data::Package>(std::move(package));
@@ -1006,8 +1008,9 @@ namespace AppInstaller::CLI::Workflow
     {
         PackageVersionKey key("", m_version, m_channel);
 
-        std::shared_ptr<IPackage> package = context.Get<Execution::Data::Package>();
+        std::shared_ptr<ICompositePackage> package = context.Get<Execution::Data::Package>();
         std::shared_ptr<IPackageVersion> requestedVersion;
+        auto availableVersions = GetAvailableVersionsForInstalledVersion(package);
 
         if (m_considerPins)
         {
@@ -1025,17 +1028,17 @@ namespace AppInstaller::CLI::Workflow
             }
 
             PinningData pinningData{ PinningData::Disposition::ReadOnly };
-            auto evaluator = pinningData.CreatePinStateEvaluator(pinBehavior, package->GetInstalledVersion());
+            auto evaluator = pinningData.CreatePinStateEvaluator(pinBehavior, GetInstalledVersion(package));
 
             // TODO: The logic here will probably have to get more difficult once we support channels
             if (Utility::IsEmptyOrWhitespace(m_version) && Utility::IsEmptyOrWhitespace(m_channel))
             {
-                requestedVersion = evaluator.GetLatestAvailableVersionForPins(package);
+                requestedVersion = evaluator.GetLatestAvailableVersionForPins(availableVersions);
 
                 if (!requestedVersion)
                 {
                     // Check whether we didn't find the latest version because it was pinned or because there wasn't one
-                    auto latestVersion = package->GetLatestAvailableVersion();
+                    auto latestVersion = availableVersions->GetLatestVersion();
                     if (latestVersion)
                     {
                         isPinned = true;
@@ -1044,7 +1047,7 @@ namespace AppInstaller::CLI::Workflow
             }
             else
             {
-                requestedVersion = package->GetAvailableVersion(key);
+                requestedVersion = availableVersions->GetVersion(key);
                 isPinned = evaluator.EvaluatePinType(requestedVersion) != PinType::Unknown;
             }
 
@@ -1065,7 +1068,7 @@ namespace AppInstaller::CLI::Workflow
         else
         {
             // The simple case: Just look up the requested version
-            requestedVersion = package->GetAvailableVersion(key);
+            requestedVersion = availableVersions->GetVersion(key);
         }
 
         std::optional<Manifest::Manifest> manifest;
@@ -1336,7 +1339,7 @@ namespace AppInstaller::CLI::Workflow
 
     void GetInstalledPackageVersion(Execution::Context& context)
     {
-        context.Add<Execution::Data::InstalledPackageVersion>(context.Get<Execution::Data::Package>()->GetInstalledVersion());
+        context.Add<Execution::Data::InstalledPackageVersion>(GetInstalledVersion(context.Get<Execution::Data::Package>()));
     }
 
     void ReportExecutionStage::operator()(Execution::Context& context) const
@@ -1346,7 +1349,7 @@ namespace AppInstaller::CLI::Workflow
 
     void ShowAppVersions(Execution::Context& context)
     {
-        auto versions = context.Get<Execution::Data::Package>()->GetAvailableVersionKeys();
+        auto versions = GetAvailableVersionsForInstalledVersion(context.Get<Execution::Data::Package>(), nullptr)->GetVersionKeys();
 
         Execution::TableOutput<2> table(context.Reporter, { Resource::String::ShowVersion, Resource::String::ShowChannel });
         for (const auto& version : versions)

--- a/src/AppInstallerCLITests/ARPChanges.cpp
+++ b/src/AppInstallerCLITests/ARPChanges.cpp
@@ -9,6 +9,7 @@
 #include <winget/Manifest.h>
 #include <winget/ARPCorrelationAlgorithms.h>
 #include <Microsoft/PredefinedInstalledSourceFactory.h>
+#include <winget/PackageVersionSelection.h>
 
 using namespace TestCommon;
 using namespace AppInstaller;
@@ -133,7 +134,7 @@ struct ARPTestContext : public Context
         AddResult(MatchResult, id, name, publisher, version);
     }
 
-    void ExpectEvent(size_t arpChanges, size_t matches, size_t overlap, IPackage* arpEntry = nullptr)
+    void ExpectEvent(size_t arpChanges, size_t matches, size_t overlap, const std::shared_ptr<ICompositePackage>& arpEntry = nullptr)
     {
         REQUIRE(Logger->WasLogSuccessfulInstallARPChangeCalled);
 
@@ -149,7 +150,7 @@ struct ARPTestContext : public Context
 
         if (arpEntry)
         {
-            auto version = arpEntry->GetInstalledVersion();
+            auto version = GetInstalledVersion(arpEntry);
             REQUIRE(version->GetProperty(PackageVersionProperty::Name) == ARPName);
             REQUIRE(version->GetProperty(PackageVersionProperty::Version) == ARPVersion);
 
@@ -202,7 +203,7 @@ struct ARPTestContext : public Context
             TestPackage::MetadataMap metadata;
             metadata[PackageVersionMetadata::Publisher] = publisher;
 
-            result.Matches.emplace_back(TestPackage::Make(manifest, std::move(metadata), std::vector<Manifest::Manifest>{}, Source), defaultFilter);
+            result.Matches.emplace_back(TestCompositePackage::Make(manifest, std::move(metadata), std::vector<Manifest::Manifest>{}, Source), defaultFilter);
         }
 };
 
@@ -259,8 +260,8 @@ TEST_CASE("ARPChanges_CheckSnapshot", "[ARPChanges][workflow]")
         {
             if (match.Package->GetProperty(PackageProperty::Id) == std::get<0>(*itr))
             {
-                REQUIRE(match.Package->GetInstalledVersion()->GetProperty(PackageVersionProperty::Version) == std::get<1>(*itr));
-                REQUIRE(match.Package->GetInstalledVersion()->GetProperty(PackageVersionProperty::Channel) == std::get<2>(*itr));
+                REQUIRE(GetInstalledVersion(match.Package)->GetProperty(PackageVersionProperty::Version) == std::get<1>(*itr));
+                REQUIRE(GetInstalledVersion(match.Package)->GetProperty(PackageVersionProperty::Channel) == std::get<2>(*itr));
 
                 snapshot.erase(itr);
                 found = true;
@@ -296,7 +297,7 @@ TEST_CASE("ARPChanges_NoChange_SingleMatch", "[ARPChanges][workflow]")
     context.AddMatchResult("MatchId1", "MatchName1", "MatchPublisher1", "MatchVersion1");
 
     context << ReportARPChanges;
-    context.ExpectEvent(0, 1, 0, context.MatchResult.Matches[0].Package.get());
+    context.ExpectEvent(0, 1, 0, context.MatchResult.Matches[0].Package);
 }
 
 TEST_CASE("ARPChanges_NoChange_MultiMatch", "[ARPChanges][workflow]")
@@ -340,7 +341,7 @@ TEST_CASE("ARPChanges_SingleChange_SingleMatch", "[ARPChanges][workflow]")
     context.AddMatchResult("MatchId1", "MatchName1", "MatchPublisher1", "MatchVersion1");
 
     context << ReportARPChanges;
-    context.ExpectEvent(1, 1, 0, context.MatchResult.Matches.back().Package.get());
+    context.ExpectEvent(1, 1, 0, context.MatchResult.Matches.back().Package);
 }
 
 TEST_CASE("ARPChanges_SingleChange_MultiMatch", "[ARPChanges][workflow]")
@@ -356,7 +357,7 @@ TEST_CASE("ARPChanges_SingleChange_MultiMatch", "[ARPChanges][workflow]")
     context.MatchResult.Matches.emplace_back(context.EverythingResult.Matches.back());
 
     context << ReportARPChanges;
-    context.ExpectEvent(1, 2, 1, context.EverythingResult.Matches.back().Package.get());
+    context.ExpectEvent(1, 2, 1, context.EverythingResult.Matches.back().Package);
 }
 
 TEST_CASE("ARPChanges_MultiChange_NoMatch", "[ARPChanges][workflow]")
@@ -387,7 +388,7 @@ TEST_CASE("ARPChanges_MultiChange_SingleMatch_NoOverlap", "[ARPChanges][workflow
     context.AddMatchResult("MatchId1", "MatchName1", "MatchPublisher1", "MatchVersion1");
 
     context << ReportARPChanges;
-    context.ExpectEvent(2, 1, 0, context.MatchResult.Matches.back().Package.get());
+    context.ExpectEvent(2, 1, 0, context.MatchResult.Matches.back().Package);
 }
 
 TEST_CASE("ARPChanges_MultiChange_SingleMatch_Overlap", "[ARPChanges][workflow]")
@@ -403,7 +404,7 @@ TEST_CASE("ARPChanges_MultiChange_SingleMatch_Overlap", "[ARPChanges][workflow]"
     context.MatchResult.Matches.emplace_back(context.EverythingResult.Matches.back());
 
     context << ReportARPChanges;
-    context.ExpectEvent(2, 1, 1, context.MatchResult.Matches.back().Package.get());
+    context.ExpectEvent(2, 1, 1, context.MatchResult.Matches.back().Package);
 }
 
 TEST_CASE("ARPChanges_MultiChange_MultiMatch_NoOverlap", "[ARPChanges][workflow]")
@@ -437,7 +438,7 @@ TEST_CASE("ARPChanges_MultiChange_MultiMatch_SingleOverlap", "[ARPChanges][workf
     context.MatchResult.Matches.emplace_back(context.EverythingResult.Matches.back());
 
     context << ReportARPChanges;
-    context.ExpectEvent(2, 2, 1, context.MatchResult.Matches.back().Package.get());
+    context.ExpectEvent(2, 2, 1, context.MatchResult.Matches.back().Package);
 }
 
 TEST_CASE("ARPChanges_MultiChange_MultiMatch_MultiOverlap", "[ARPChanges][workflow]")

--- a/src/AppInstallerCLITests/CompositeSource.cpp
+++ b/src/AppInstallerCLITests/CompositeSource.cpp
@@ -720,20 +720,15 @@ TEST_CASE("CompositeSource_IsSame", "[CompositeSource]")
 {
     CompositeTestSetup setup;
     setup.Installed->Everything.Matches.emplace_back(MakeInstalled().WithPFN("sortof_apfn"), Criteria());
-    setup.Available->Everything.Matches.emplace_back(MakeAvailable(setup.Available).WithPFN("sortof_apfn"), Criteria());
 
     SearchResult result1 = setup.Search();
     REQUIRE(result1.Matches.size() == 1);
-    REQUIRE(result1.Matches[0].Package->GetAvailable().size() == 1);
 
     SearchResult result2 = setup.Search();
     REQUIRE(result2.Matches.size() == 1);
-    REQUIRE(result2.Matches[0].Package->GetAvailable().size() == 1);
 
     REQUIRE(result1.Matches[0].Package->GetInstalled());
     REQUIRE(result1.Matches[0].Package->GetInstalled()->IsSame(result1.Matches[0].Package->GetInstalled().get()));
-
-    REQUIRE(result1.Matches[0].Package->GetAvailable()[0]->IsSame(result2.Matches[0].Package->GetAvailable()[0].get()));
 }
 
 TEST_CASE("CompositeSource_AvailableSearchFailure", "[CompositeSource]")
@@ -1082,8 +1077,7 @@ TEST_CASE("CompositeSource_NullAvailableVersion", "[CompositeSource]")
     setup.Available->Everything.Matches.emplace_back(MakeInstalled(), Criteria());
 
     // We are mostly testing to see if a null available version causes an AV or not
-    SearchResult result = setup.Search();
-    REQUIRE(result.Matches.size() == 1);
+    REQUIRE_THROWS_HR(setup.Search(), E_UNEXPECTED);
 }
 
 struct ExpectedResultForPinBehavior

--- a/src/AppInstallerCLITests/DependenciesTestSource.h
+++ b/src/AppInstallerCLITests/DependenciesTestSource.h
@@ -188,9 +188,9 @@ namespace TestCommon
                 //auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
                 result.Matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
                             std::vector<Manifest>{ manifest },
                             shared_from_this()
                         ),
@@ -200,7 +200,7 @@ namespace TestCommon
             {
                 result.Matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             std::vector<Manifest>{ manifest },
                             shared_from_this()
                         ),

--- a/src/AppInstallerCLITests/PackageTrackingCatalog.cpp
+++ b/src/AppInstallerCLITests/PackageTrackingCatalog.cpp
@@ -86,8 +86,9 @@ TEST_CASE("TrackingCatalog_Install", "[tracking_catalog]")
 
     SearchResult resultAfter = catalog.Search(request);
     REQUIRE(resultAfter.Matches.size() == 1);
+    REQUIRE(resultAfter.Matches[0].Package->GetAvailable().size() == 1);
 
-    auto trackingVersion = resultAfter.Matches[0].Package->GetLatestAvailableVersion();
+    auto trackingVersion = resultAfter.Matches[0].Package->GetAvailable()[0]->GetLatestVersion();
     REQUIRE(trackingVersion);
 
     auto metadata = trackingVersion->GetMetadata();
@@ -113,7 +114,8 @@ TEST_CASE("TrackingCatalog_Reinstall", "[tracking_catalog]")
 
     SearchResult resultBefore = catalog.Search(request);
     REQUIRE(resultBefore.Matches.size() == 1);
-    REQUIRE(resultBefore.Matches[0].Package->GetLatestAvailableVersion()->GetProperty(PackageVersionProperty::Name) ==
+    REQUIRE(resultBefore.Matches[0].Package->GetAvailable().size() == 1);
+    REQUIRE(resultBefore.Matches[0].Package->GetAvailable()[0]->GetLatestVersion()->GetProperty(PackageVersionProperty::Name) ==
         manifest.DefaultLocalization.Get<Localization::PackageName>());
 
     // Change name
@@ -124,7 +126,8 @@ TEST_CASE("TrackingCatalog_Reinstall", "[tracking_catalog]")
 
     SearchResult resultAfter = catalog.Search(request);
     REQUIRE(resultAfter.Matches.size() == 1);
-    REQUIRE(resultBefore.Matches[0].Package->GetLatestAvailableVersion()->GetProperty(PackageVersionProperty::Name) ==
+    REQUIRE(resultAfter.Matches[0].Package->GetAvailable().size() == 1);
+    REQUIRE(resultAfter.Matches[0].Package->GetAvailable()[0]->GetLatestVersion()->GetProperty(PackageVersionProperty::Name) ==
         newName);
 }
 
@@ -147,17 +150,19 @@ TEST_CASE("TrackingCatalog_Upgrade", "[tracking_catalog]")
 
     SearchResult resultBefore = catalog.Search(request);
     REQUIRE(resultBefore.Matches.size() == 1);
-    REQUIRE(resultBefore.Matches[0].Package->GetLatestAvailableVersion()->GetProperty(PackageVersionProperty::Version) ==
+    REQUIRE(resultBefore.Matches[0].Package->GetAvailable().size() == 1);
+    REQUIRE(resultBefore.Matches[0].Package->GetAvailable()[0]->GetLatestVersion()->GetProperty(PackageVersionProperty::Version) ==
         manifest.Version);
 
-    // Change name
+    // Change version
     manifest.Version = "99.1.2.3";
 
     catalog.RecordInstall(manifest, manifest.Installers[0], true);
 
     SearchResult resultAfter = catalog.Search(request);
     REQUIRE(resultAfter.Matches.size() == 1);
-    REQUIRE(resultBefore.Matches[0].Package->GetLatestAvailableVersion()->GetProperty(PackageVersionProperty::Version) ==
+    REQUIRE(resultAfter.Matches[0].Package->GetAvailable().size() == 1);
+    REQUIRE(resultAfter.Matches[0].Package->GetAvailable()[0]->GetLatestVersion()->GetProperty(PackageVersionProperty::Version) ==
         manifest.Version);
 }
 

--- a/src/AppInstallerCLITests/SQLiteIndexSource.cpp
+++ b/src/AppInstallerCLITests/SQLiteIndexSource.cpp
@@ -86,7 +86,7 @@ TEST_CASE("SQLiteIndexSource_Id", "[sqliteindexsource]")
     auto results = source->Search(request);
     REQUIRE(results.Matches.size() == 1);
     REQUIRE(results.Matches[0].Package);
-    auto latestVersion = results.Matches[0].Package->GetLatestAvailableVersion();
+    auto latestVersion = results.Matches[0].Package->GetAvailable()[0]->GetLatestVersion();
 
     REQUIRE(latestVersion->GetProperty(PackageVersionProperty::Id).get() == manifest.Id);
 }
@@ -107,7 +107,7 @@ TEST_CASE("SQLiteIndexSource_Name", "[sqliteindexsource]")
     auto results = source->Search(request);
     REQUIRE(results.Matches.size() == 1);
     REQUIRE(results.Matches[0].Package);
-    auto latestVersion = results.Matches[0].Package->GetLatestAvailableVersion();
+    auto latestVersion = results.Matches[0].Package->GetAvailable()[0]->GetLatestVersion();
 
     REQUIRE(latestVersion->GetProperty(PackageVersionProperty::Name).get() == manifest.DefaultLocalization.Get<Localization::PackageName>());
 }
@@ -128,8 +128,9 @@ TEST_CASE("SQLiteIndexSource_Versions", "[sqliteindexsource]")
     auto results = source->Search(request);
     REQUIRE(results.Matches.size() == 1);
     REQUIRE(results.Matches[0].Package);
+    REQUIRE(results.Matches[0].Package->GetAvailable().size() == 1);
 
-    auto result = results.Matches[0].Package->GetAvailableVersionKeys();
+    auto result = results.Matches[0].Package->GetAvailable()[0]->GetVersionKeys();
     REQUIRE(result.size() == 1);
     REQUIRE(result[0].Version == manifest.Version);
     REQUIRE(result[0].Channel == manifest.Channel);
@@ -151,9 +152,10 @@ TEST_CASE("SQLiteIndexSource_GetManifest", "[sqliteindexsource]")
     auto results = source->Search(request);
     REQUIRE(results.Matches.size() == 1);
     REQUIRE(results.Matches[0].Package);
-    auto package = results.Matches[0].Package.get();
+    REQUIRE(results.Matches[0].Package->GetAvailable().size() == 1);
+    auto package = results.Matches[0].Package->GetAvailable()[0];
 
-    auto specificResultVersion = package->GetAvailableVersion(PackageVersionKey("", manifest.Version, manifest.Channel));
+    auto specificResultVersion = package->GetVersion(PackageVersionKey("", manifest.Version, manifest.Channel));
     REQUIRE(specificResultVersion);
     auto specificResult = specificResultVersion->GetManifest();
     REQUIRE(specificResult.Id == manifest.Id);
@@ -161,7 +163,7 @@ TEST_CASE("SQLiteIndexSource_GetManifest", "[sqliteindexsource]")
     REQUIRE(specificResult.Version == manifest.Version);
     REQUIRE(specificResult.Channel == manifest.Channel);
 
-    auto latestResultVersion = package->GetAvailableVersion(PackageVersionKey("", "", manifest.Channel));
+    auto latestResultVersion = package->GetVersion(PackageVersionKey("", "", manifest.Channel));
     REQUIRE(latestResultVersion);
     auto latestResult = latestResultVersion->GetManifest();
     REQUIRE(latestResult.Id == manifest.Id);
@@ -169,7 +171,7 @@ TEST_CASE("SQLiteIndexSource_GetManifest", "[sqliteindexsource]")
     REQUIRE(latestResult.Version == manifest.Version);
     REQUIRE(latestResult.Channel == manifest.Channel);
 
-    auto noResultVersion = package->GetAvailableVersion(PackageVersionKey("", "blargle", "flargle"));
+    auto noResultVersion = package->GetVersion(PackageVersionKey("", "blargle", "flargle"));
     REQUIRE(!noResultVersion);
 }
 
@@ -188,9 +190,11 @@ TEST_CASE("SQLiteIndexSource_IsSame", "[sqliteindexsource]")
 
     auto result1 = source->Search(request);
     REQUIRE(result1.Matches.size() == 1);
+    REQUIRE(result1.Matches[0].Package->GetAvailable().size() == 1);
 
     auto result2 = source->Search(request);
     REQUIRE(result2.Matches.size() == 1);
+    REQUIRE(result2.Matches[0].Package->GetAvailable().size() == 1);
 
-    REQUIRE(result1.Matches[0].Package->IsSame(result2.Matches[0].Package.get()));
+    REQUIRE(result1.Matches[0].Package->GetAvailable()[0]->IsSame(result2.Matches[0].Package->GetAvailable()[0].get()));
 }

--- a/src/AppInstallerCLITests/Sources.cpp
+++ b/src/AppInstallerCLITests/Sources.cpp
@@ -195,9 +195,9 @@ namespace
             PackageMatchFilter testMatchFilter1{ PackageMatchField::Id, MatchType::Exact, "test" };
             PackageMatchFilter testMatchFilter2{ PackageMatchField::Name, MatchType::Exact, "test" };
             PackageMatchFilter testMatchFilter3{ PackageMatchField::Id, MatchType::CaseInsensitive, "test" };
-            result.Matches.emplace_back(std::shared_ptr<IPackage>(), testMatchFilter1);
-            result.Matches.emplace_back(std::shared_ptr<IPackage>(), testMatchFilter2);
-            result.Matches.emplace_back(std::shared_ptr<IPackage>(), testMatchFilter3);
+            result.Matches.emplace_back(nullptr, testMatchFilter1);
+            result.Matches.emplace_back(nullptr, testMatchFilter2);
+            result.Matches.emplace_back(nullptr, testMatchFilter3);
             return result;
         }
     };

--- a/src/AppInstallerCLITests/TestSource.cpp
+++ b/src/AppInstallerCLITests/TestSource.cpp
@@ -285,7 +285,7 @@ namespace TestCommon
 
     std::vector<std::shared_ptr<AppInstaller::Repository::IPackage>> TestCompositePackage::GetAvailable()
     {
-        return Available;
+        return { Available.begin(), Available.end() };
     }
 
     const SourceDetails& TestSource::GetDetails() const

--- a/src/AppInstallerCLITests/TestSource.h
+++ b/src/AppInstallerCLITests/TestSource.h
@@ -101,8 +101,8 @@ namespace TestCommon
         std::shared_ptr<AppInstaller::Repository::IPackage> GetInstalled() override;
         std::vector<std::shared_ptr<AppInstaller::Repository::IPackage>> GetAvailable() override;
 
-        std::shared_ptr<AppInstaller::Repository::IPackage> Installed;
-        std::vector<std::shared_ptr<AppInstaller::Repository::IPackage>> Available;
+        std::shared_ptr<TestPackage> Installed;
+        std::vector<std::shared_ptr<TestPackage>> Available;
     };
 
     // An ISource implementation for use across the test code.

--- a/src/AppInstallerCLITests/TestSource.h
+++ b/src/AppInstallerCLITests/TestSource.h
@@ -56,7 +56,7 @@ namespace TestCommon
         TestPackage(const std::vector<Manifest>& available, std::weak_ptr<const ISource> source = {}, bool hideSystemReferenceStringsOnVersion = false);
 
         // Create a package with an installed version, metadata, and optionally available versions.
-        TestPackage(const Manifest& installed, MetadataMap installationMetadata, const std::vector<Manifest>& available = {}, std::weak_ptr<const ISource> source = {});
+        TestPackage(const Manifest& installed, MetadataMap installationMetadata, std::weak_ptr<const ISource> source = {});
 
         template <typename... Args>
         static std::shared_ptr<TestPackage> Make(Args&&... args)
@@ -65,16 +65,44 @@ namespace TestCommon
         }
 
         AppInstaller::Utility::LocIndString GetProperty(AppInstaller::Repository::PackageProperty property) const override;
-        std::shared_ptr<AppInstaller::Repository::IPackageVersion> GetInstalledVersion() const override;
-        std::vector<AppInstaller::Repository::PackageVersionKey> GetAvailableVersionKeys() const override;
-        std::shared_ptr<AppInstaller::Repository::IPackageVersion> GetLatestAvailableVersion() const override;
-        std::shared_ptr<AppInstaller::Repository::IPackageVersion> GetAvailableVersion(const AppInstaller::Repository::PackageVersionKey& versionKey) const override;
+        std::vector<AppInstaller::Repository::PackageVersionKey> GetVersionKeys() const override;
+        std::shared_ptr<AppInstaller::Repository::IPackageVersion> GetLatestVersion() const override;
+        std::shared_ptr<AppInstaller::Repository::IPackageVersion> GetVersion(const AppInstaller::Repository::PackageVersionKey& versionKey) const override;
+        AppInstaller::Repository::Source GetSource() const override;
         bool IsSame(const IPackage* other) const override;
         const void* CastTo(AppInstaller::Repository::IPackageType type) const override;
 
-        std::shared_ptr<AppInstaller::Repository::IPackageVersion> InstalledVersion;
-        std::vector<std::shared_ptr<AppInstaller::Repository::IPackageVersion>> AvailableVersions;
+        std::vector<std::shared_ptr<AppInstaller::Repository::IPackageVersion>> Versions;
+        std::weak_ptr<const ISource> Source;
         std::function<bool(const IPackage*, const IPackage*)> IsSameOverride;
+    };
+
+    // ICompositePackage for TestSource
+    struct TestCompositePackage : public AppInstaller::Repository::ICompositePackage
+    {
+        using Manifest = AppInstaller::Manifest::Manifest;
+        using ISource = AppInstaller::Repository::ISource;
+        using LocIndString = AppInstaller::Utility::LocIndString;
+        using MetadataMap = TestPackageVersion::MetadataMap;
+
+        // Create a package with only available versions using these manifests.
+        TestCompositePackage(const std::vector<Manifest>& available, std::weak_ptr<const ISource> source = {}, bool hideSystemReferenceStringsOnVersion = false);
+
+        // Create a package with an installed version, metadata, and optionally available versions.
+        TestCompositePackage(const Manifest& installed, MetadataMap installationMetadata, const std::vector<Manifest>& available = {}, std::weak_ptr<const ISource> source = {});
+
+        template <typename... Args>
+        static std::shared_ptr<TestCompositePackage> Make(Args&&... args)
+        {
+            return std::make_shared<TestCompositePackage>(std::forward<Args>(args)...);
+        }
+
+        AppInstaller::Utility::LocIndString GetProperty(AppInstaller::Repository::PackageProperty property) const override;
+        std::shared_ptr<AppInstaller::Repository::IPackage> GetInstalled() override;
+        std::vector<std::shared_ptr<AppInstaller::Repository::IPackage>> GetAvailable() override;
+
+        std::shared_ptr<AppInstaller::Repository::IPackage> Installed;
+        std::vector<std::shared_ptr<AppInstaller::Repository::IPackage>> Available;
     };
 
     // An ISource implementation for use across the test code.

--- a/src/AppInstallerCLITests/WorkflowCommon.cpp
+++ b/src/AppInstallerCLITests/WorkflowCommon.cpp
@@ -27,7 +27,7 @@ namespace TestCommon
                 auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(std::vector<Manifest>{ manifest }, source),
+                        TestCompositePackage::Make(std::vector<Manifest>{ manifest }, source),
                         PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestQueryReturnOne")));
             });
 
@@ -37,13 +37,13 @@ namespace TestCommon
                 auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(std::vector<Manifest>{ manifest }, source),
+                        TestCompositePackage::Make(std::vector<Manifest>{ manifest }, source),
                         PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestQueryReturnTwo")));
 
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("Manifest-Good.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(std::vector<Manifest>{ manifest2 }, source),
+                        TestCompositePackage::Make(std::vector<Manifest>{ manifest2 }, source),
                         PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestQueryReturnTwo")));
             });
 
@@ -55,9 +55,9 @@ namespace TestCommon
                 auto manifest3 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2.yaml"));
 
                 auto testPackage =
-                    TestPackage::Make(
+                    TestCompositePackage::Make(
                         manifest,
-                        TestPackage::MetadataMap
+                        TestCompositePackage::MetadataMap
                         {
                             { PackageVersionMetadata::InstalledType, "Exe" },
                             { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
@@ -66,7 +66,10 @@ namespace TestCommon
                         std::vector<Manifest>{ manifest3, manifest2, manifest },
                         source
                         );
-                testPackage->IsSameOverride = [](const IPackage*, const IPackage*) { return true; };
+                for (auto& availablePackage : testPackage->Available)
+                {
+                    availablePackage->IsSameOverride = [](const IPackage*, const IPackage*) { return true; };
+                }
                 matches.emplace_back(
                     ResultMatch(
                         testPackage,
@@ -81,9 +84,9 @@ namespace TestCommon
                 auto manifest3 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2_LicenseAgreement.yaml"));
 
                 auto testPackage =
-                    TestPackage::Make(
+                    TestCompositePackage::Make(
                         manifest,
-                        TestPackage::MetadataMap
+                        TestCompositePackage::MetadataMap
                         {
                             { PackageVersionMetadata::InstalledType, "Exe" },
                             { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
@@ -92,7 +95,10 @@ namespace TestCommon
                         std::vector<Manifest>{ manifest3, manifest2, manifest },
                         source
                         );
-                testPackage->IsSameOverride = [](const IPackage*, const IPackage*) { return true; };
+                for (auto& availablePackage : testPackage->Available)
+                {
+                    availablePackage->IsSameOverride = [](const IPackage*, const IPackage*) { return true; };
+                }
                 matches.emplace_back(
                     ResultMatch(
                         testPackage,
@@ -106,9 +112,9 @@ namespace TestCommon
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Portable.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Portable" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Portable" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             source
                         ),
@@ -123,9 +129,9 @@ namespace TestCommon
 
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             source
                         ),
@@ -140,9 +146,9 @@ namespace TestCommon
 
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             source
                         ),
@@ -157,9 +163,9 @@ namespace TestCommon
 
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap
+                            TestCompositePackage::MetadataMap
                             {
                                 { PackageVersionMetadata::InstalledType, "Msix" },
                                 { PackageVersionMetadata::PinnedState, "PinnedByManifest" },
@@ -177,9 +183,9 @@ namespace TestCommon
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Zip_Exe.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             source
                         ),
@@ -195,9 +201,9 @@ namespace TestCommon
                 installed.Version = "1.0.0.0";
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             installed,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "MSStore" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "MSStore" } },
                             std::vector<Manifest>{ available },
                             source
                         ),
@@ -211,9 +217,9 @@ namespace TestCommon
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_ExpectedReturnCodes.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             source
                         ),
@@ -229,9 +235,9 @@ namespace TestCommon
                 installed.Version = "unknown";
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             installed,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
                             std::vector<Manifest>{ available },
                             source
                         ),
@@ -245,9 +251,9 @@ namespace TestCommon
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest2,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             source
                         ),
@@ -261,9 +267,9 @@ namespace TestCommon
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             source
                         ),
@@ -277,9 +283,9 @@ namespace TestCommon
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_ARPInstallerType.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             source
                         ),
@@ -293,9 +299,9 @@ namespace TestCommon
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_UnsupportedArgs.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             source
                         ),
@@ -308,7 +314,7 @@ namespace TestCommon
                 auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             std::vector<Manifest>{ manifest },
                             source
                         ),
@@ -322,9 +328,9 @@ namespace TestCommon
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_ExeDependencies.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap
+                            TestCompositePackage::MetadataMap
                             {
                                 { PackageVersionMetadata::InstalledType, "Exe" },
                                 { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
@@ -342,7 +348,7 @@ namespace TestCommon
                 auto manifest = YamlParser::CreateFromPath(TestDataFile("Installer_Msix_WFDependency.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             std::vector<Manifest>{ manifest },
                             source
                         ),
@@ -356,9 +362,9 @@ namespace TestCommon
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2_LicenseAgreement.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            TestCompositePackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             source
                         ),
@@ -373,9 +379,9 @@ namespace TestCommon
                 auto manifest3 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2.yaml"));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest,
-                            TestPackage::MetadataMap
+                            TestCompositePackage::MetadataMap
                             {
                                 { PackageVersionMetadata::InstalledType, "Exe" },
                                 { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
@@ -387,9 +393,9 @@ namespace TestCommon
                         PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
                 matches.emplace_back(
                     ResultMatch(
-                        TestPackage::Make(
+                        TestCompositePackage::Make(
                             manifest2,
-                            TestPackage::MetadataMap
+                            TestCompositePackage::MetadataMap
                             {
                                 { PackageVersionMetadata::InstalledType, "Exe" },
                                 { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },

--- a/src/AppInstallerRepositoryCore/ARPCorrelationAlgorithms.cpp
+++ b/src/AppInstallerRepositoryCore/ARPCorrelationAlgorithms.cpp
@@ -145,8 +145,8 @@ namespace AppInstaller::Repository::Correlation
     {
         // Name and Publisher are available as multi properties, but for ARP entries there will only be 0 or 1 values.
         NameAndPublisher arpNameAndPublisher(
-            NormalizeAndPrepareName(arpEntry.Entry->GetInstalledVersion()->GetProperty(PackageVersionProperty::Name).get()),
-            NormalizeAndPreparePublisher(arpEntry.Entry->GetInstalledVersion()->GetProperty(PackageVersionProperty::Publisher).get()));
+            NormalizeAndPrepareName(arpEntry.Entry->GetLatestVersion()->GetProperty(PackageVersionProperty::Name).get()),
+            NormalizeAndPreparePublisher(arpEntry.Entry->GetLatestVersion()->GetProperty(PackageVersionProperty::Publisher).get()));
 
         // Get the best score across all localizations
         double bestMatchingScore = 0;

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
@@ -406,10 +406,12 @@
     <ClInclude Include="Public\winget\CheckpointDatabase.h" />
     <ClInclude Include="Public\winget\IconExtraction.h" />
     <ClInclude Include="Public\winget\InstalledFilesCorrelation.h" />
+    <ClInclude Include="Public\winget\InstalledStatus.h" />
     <ClInclude Include="Public\winget\InstallerMetadataCollectionContext.h" />
     <ClInclude Include="Public\winget\ManifestJSONParser.h" />
     <ClInclude Include="Public\winget\ARPCorrelationAlgorithms.h" />
     <ClInclude Include="Public\winget\PackageTrackingCatalog.h" />
+    <ClInclude Include="Public\winget\PackageVersionSelection.h" />
     <ClInclude Include="Public\winget\PinningData.h" />
     <ClInclude Include="Public\winget\PortableIndex.h" />
     <ClInclude Include="Public\winget\RepositorySearch.h" />
@@ -492,6 +494,7 @@
     <ClCompile Include="PackageDependenciesValidation.cpp" />
     <ClCompile Include="PackageInstalledStatus.cpp" />
     <ClCompile Include="PackageTrackingCatalog.cpp" />
+    <ClCompile Include="PackageVersionSelection.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
@@ -318,9 +318,6 @@
     <ClInclude Include="Microsoft\Schema\Portable_1_0\PortableTable.h">
       <Filter>Microsoft\Schema\Portable_1_0</Filter>
     </ClInclude>
-    <ClInclude Include="Microsoft\PortableIndex.h">
-      <Filter>Microsoft</Filter>
-    </ClInclude>
     <ClInclude Include="Microsoft\Schema\IPortableIndex.h">
       <Filter>Microsoft\Schema</Filter>
     </ClInclude>
@@ -378,9 +375,6 @@
     <ClInclude Include="Microsoft\Schema\ICheckpointDatabase.h">
       <Filter>Microsoft\Schema</Filter>
     </ClInclude>
-    <ClInclude Include="Microsoft\CheckpointDatabase.h">
-      <Filter>Microsoft</Filter>
-    </ClInclude>
     <ClInclude Include="Microsoft\Schema\Checkpoint_1_0\CheckpointDataTable.h">
       <Filter>Microsoft\Schema\Checkpoint_1_0</Filter>
     </ClInclude>
@@ -401,6 +395,15 @@
     </ClInclude>
     <ClInclude Include="Rest\Schema\AuthenticationInfoParser.h">
       <Filter>Rest\Schema</Filter>
+    </ClInclude>
+    <ClInclude Include="Public\winget\CheckpointDatabase.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Public\winget\PinningData.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Public\winget\PortableIndex.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -631,6 +634,9 @@
     </ClCompile>
     <ClCompile Include="Rest\Schema\AuthenticationInfoParser.cpp">
       <Filter>Rest\Schema</Filter>
+    </ClCompile>
+    <ClCompile Include="PinningData.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
@@ -396,14 +396,20 @@
     <ClInclude Include="Rest\Schema\AuthenticationInfoParser.h">
       <Filter>Rest\Schema</Filter>
     </ClInclude>
-    <ClInclude Include="Public\winget\CheckpointDatabase.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="Public\winget\PinningData.h">
-      <Filter>Header Files</Filter>
+      <Filter>Public\winget</Filter>
     </ClInclude>
     <ClInclude Include="Public\winget\PortableIndex.h">
-      <Filter>Header Files</Filter>
+      <Filter>Public\winget</Filter>
+    </ClInclude>
+    <ClInclude Include="Public\winget\CheckpointDatabase.h">
+      <Filter>Public\winget</Filter>
+    </ClInclude>
+    <ClInclude Include="Public\winget\InstalledStatus.h">
+      <Filter>Public\winget</Filter>
+    </ClInclude>
+    <ClInclude Include="Public\winget\PackageVersionSelection.h">
+      <Filter>Public\winget</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -636,6 +642,9 @@
       <Filter>Rest\Schema</Filter>
     </ClCompile>
     <ClCompile Include="PinningData.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PackageVersionSelection.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -421,15 +421,9 @@ namespace AppInstaller::Repository
         {
             CompositePackage(const std::shared_ptr<ICompositePackage>& installedPackage, const std::shared_ptr<ICompositePackage>& availablePackage = {})
             {
-                // Grab the installed version's channel to allow for filtering in calls to get available info.
                 if (installedPackage)
                 {
                     m_installedPackage = installedPackage->GetInstalled();
-                    auto installedVersion = m_installedPackage->GetLatestVersion();
-                    if (installedVersion)
-                    {
-                        m_installedChannel = installedVersion->GetProperty(PackageVersionProperty::Channel);
-                    }
                 }
 
                 AddAvailablePackage(availablePackage);
@@ -538,7 +532,6 @@ namespace AppInstaller::Repository
             }
 
             std::shared_ptr<IPackage> m_installedPackage;
-            Utility::LocIndString m_installedChannel;
             Source m_trackingSource;
             std::shared_ptr<IPackage> m_trackingPackage;
             std::shared_ptr<IPackageVersion> m_trackingPackageVersion;

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
@@ -365,7 +365,7 @@ namespace AppInstaller::Repository::Microsoft
 
             std::vector<std::shared_ptr<IPackage>> GetAvailable() override
             {
-                return m_isInstalled ? std::vector<std::shared_ptr<IPackage>>{ shared_from_this() } : std::vector<std::shared_ptr<IPackage>>{};
+                return m_isInstalled ? std::vector<std::shared_ptr<IPackage>>{} : std::vector<std::shared_ptr<IPackage>>{ shared_from_this() };
             }
 
         private:

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
@@ -214,17 +214,20 @@ namespace AppInstaller::Repository::Microsoft
             SQLiteIndex::IdType m_manifestId;
         };
 
-        // The base for IPackage implementations here.
-        struct PackageBase : public SourceReference
+        // The IPackage implementation here.
+        struct SQLitePackage : public std::enable_shared_from_this<SQLitePackage>, public SourceReference, public IPackage, public ICompositePackage
         {
-            PackageBase(const std::shared_ptr<SQLiteIndexSource>& source, SQLiteIndex::IdType idId) :
-                SourceReference(source), m_idId(idId) {}
+            static constexpr IPackageType PackageType = IPackageType::SQLitePackage;
 
+            SQLitePackage(const std::shared_ptr<SQLiteIndexSource>& source, SQLiteIndex::IdType idId, bool isInstalled) :
+                SourceReference(source), m_idId(idId), m_isInstalled(isInstalled) {}
+
+            // Inherited via IPackage
             Utility::LocIndString GetProperty(PackageProperty property) const
             {
                 Utility::LocIndString result;
 
-                std::shared_ptr<IPackageVersion> truth = GetLatestVersionInternal();
+                std::shared_ptr<IPackageVersion> truth = GetLatestVersion();
                 if (truth)
                 {
                     switch (property)
@@ -239,19 +242,46 @@ namespace AppInstaller::Repository::Microsoft
                 }
                 else
                 {
-                    AICLI_LOG(Repo, Verbose, << "PackageBase: No manifest was found for the package with id# '" << m_idId << "'");
+                    AICLI_LOG(Repo, Verbose, << "SQLitePackage: No manifest was found for the package with id# '" << m_idId << "'");
                 }
 
                 return result;
             }
 
-            bool IsSame(const PackageBase& other) const
+            std::vector<PackageVersionKey> GetVersionKeys() const override
             {
-                return GetReferenceSource()->IsSame(other.GetReferenceSource().get()) && m_idId == other.m_idId;
+                std::shared_ptr<SQLiteIndexSource> source = GetReferenceSource();
+
+                {
+                    auto sharedLock = m_versionKeysLock.lock_shared();
+
+                    if (!m_versionKeys.empty())
+                    {
+                        return m_versionKeys;
+                    }
+                }
+
+                auto exclusiveLock = m_versionKeysLock.lock_exclusive();
+
+                if (!m_versionKeys.empty())
+                {
+                    return m_versionKeys;
+                }
+
+                std::vector<SQLiteIndex::VersionKey> versions = source->GetIndex().GetVersionKeysById(m_idId);
+
+                for (const auto& vk : versions)
+                {
+                    std::string version = vk.VersionAndChannel.GetVersion().ToString();
+                    std::string channel = vk.VersionAndChannel.GetChannel().ToString();
+                    m_versionKeys.emplace_back(source->GetIdentifier(), version, channel);
+                    m_versionKeysMap.emplace(MapKey{ std::move(version), std::move(channel) }, vk.ManifestId);
+                }
+
+                return m_versionKeys;
             }
 
-        protected:
-            std::shared_ptr<IPackageVersion> GetLatestVersionInternal() const
+            std::shared_ptr<IPackageVersion> GetLatestVersion() const override
             {
                 std::shared_ptr<SQLiteIndexSource> source = GetReferenceSource();
                 std::optional<SQLiteIndex::IdType> manifestId = source->GetIndex().GetManifestIdByKey(m_idId, {}, {});
@@ -264,66 +294,7 @@ namespace AppInstaller::Repository::Microsoft
                 return {};
             }
 
-            SQLiteIndex::IdType m_idId;
-        };
-
-        // The IPackage impl for SQLiteIndexSource of Available packages.
-        struct AvailablePackage : public PackageBase, public IPackage
-        {
-            using PackageBase::PackageBase;
-
-            static constexpr IPackageType PackageType = IPackageType::SQLiteAvailablePackage;
-
-            // Inherited via IPackage
-            Utility::LocIndString GetProperty(PackageProperty property) const override
-            {
-                return PackageBase::GetProperty(property);
-            }
-
-            std::shared_ptr<IPackageVersion> GetInstalledVersion() const override
-            {
-                return {};
-            }
-
-            std::vector<PackageVersionKey> GetAvailableVersionKeys() const override
-            {
-                std::shared_ptr<SQLiteIndexSource> source = GetReferenceSource();
-
-                {
-                    auto sharedLock = m_availableVersionKeysLock.lock_shared();
-
-                    if (!m_availableVersionKeys.empty())
-                    {
-                        return m_availableVersionKeys;
-                    }
-                }
-
-                auto exclusiveLock = m_availableVersionKeysLock.lock_exclusive();
-
-                if (!m_availableVersionKeys.empty())
-                {
-                    return m_availableVersionKeys;
-                }
-
-                std::vector<SQLiteIndex::VersionKey> versions = source->GetIndex().GetVersionKeysById(m_idId);
-
-                for (const auto& vk : versions)
-                {
-                    std::string version = vk.VersionAndChannel.GetVersion().ToString();
-                    std::string channel = vk.VersionAndChannel.GetChannel().ToString();
-                    m_availableVersionKeys.emplace_back(source->GetIdentifier(), version, channel);
-                    m_availableVersionKeysMap.emplace(MapKey{ std::move(version), std::move(channel) }, vk.ManifestId);
-                }
-
-                return m_availableVersionKeys;
-            }
-
-            std::shared_ptr<IPackageVersion> GetLatestAvailableVersion() const override
-            {
-                return GetLatestVersionInternal();
-            }
-
-            std::shared_ptr<IPackageVersion> GetAvailableVersion(const PackageVersionKey& versionKey) const override
+            std::shared_ptr<IPackageVersion> GetVersion(const PackageVersionKey& versionKey) const override
             {
                 std::shared_ptr<SQLiteIndexSource> source = GetReferenceSource();
 
@@ -337,10 +308,10 @@ namespace AppInstaller::Repository::Microsoft
 
                 {
                     MapKey requested{ versionKey.Version, versionKey.Channel };
-                    auto sharedLock = m_availableVersionKeysLock.lock_shared();
+                    auto sharedLock = m_versionKeysLock.lock_shared();
 
-                    auto itr = m_availableVersionKeysMap.find(requested);
-                    if (itr != m_availableVersionKeysMap.end())
+                    auto itr = m_versionKeysMap.find(requested);
+                    if (itr != m_versionKeysMap.end())
                     {
                         manifestId = itr->second;
                     }
@@ -359,13 +330,18 @@ namespace AppInstaller::Repository::Microsoft
                 return {};
             }
 
+            Source GetSource() const override
+            {
+                return Source{ GetReferenceSource() };
+            }
+
             bool IsSame(const IPackage* other) const override
             {
-                const AvailablePackage* otherAvailable = PackageCast<const AvailablePackage*>(other);
+                const SQLitePackage* otherSQLite = PackageCast<const SQLitePackage*>(other);
 
-                if (otherAvailable)
+                if (otherSQLite)
                 {
-                    return PackageBase::IsSame(*otherAvailable);
+                    return GetReferenceSource()->IsSame(otherSQLite->GetReferenceSource().get()) && m_idId == otherSQLite->m_idId;
                 }
 
                 return false;
@@ -379,6 +355,17 @@ namespace AppInstaller::Repository::Microsoft
                 }
 
                 return nullptr;
+            }
+
+            // Inherited via ICompositePackage
+            std::shared_ptr<IPackage> GetInstalled() override
+            {
+                return m_isInstalled ? shared_from_this() : std::shared_ptr<IPackage>{};
+            }
+
+            std::vector<std::shared_ptr<IPackage>> GetAvailable() override
+            {
+                return m_isInstalled ? std::vector<std::shared_ptr<IPackage>>{ shared_from_this() } : std::vector<std::shared_ptr<IPackage>>{};
             }
 
         private:
@@ -405,66 +392,13 @@ namespace AppInstaller::Repository::Microsoft
                 }
             };
 
+            SQLiteIndex::IdType m_idId;
+            bool m_isInstalled;
+
             // To avoid removing const from the interface
-            mutable wil::srwlock m_availableVersionKeysLock;
-            mutable std::vector<PackageVersionKey> m_availableVersionKeys;
-            mutable std::map<MapKey, SQLiteIndex::IdType> m_availableVersionKeysMap;
-        };
-
-        // The IPackage impl for SQLiteIndexSource of Installed packages.
-        struct InstalledPackage : public PackageBase, public IPackage
-        {
-            using PackageBase::PackageBase;
-
-            static constexpr IPackageType PackageType = IPackageType::SQLiteInstalledPackage;
-
-            // Inherited via IPackage
-            Utility::LocIndString GetProperty(PackageProperty property) const override
-            {
-                return PackageBase::GetProperty(property);
-            }
-
-            std::shared_ptr<IPackageVersion> GetInstalledVersion() const override
-            {
-                return GetLatestVersionInternal();
-            }
-
-            std::vector<PackageVersionKey> GetAvailableVersionKeys() const override
-            {
-                return {};
-            }
-
-            std::shared_ptr<IPackageVersion> GetLatestAvailableVersion() const override
-            {
-                return {};
-            }
-
-            std::shared_ptr<IPackageVersion> GetAvailableVersion(const PackageVersionKey&) const override
-            {
-                return {};
-            }
-
-            bool IsSame(const IPackage* other) const override
-            {
-                const InstalledPackage* otherInstalled = PackageCast<const InstalledPackage*>(other);
-
-                if (otherInstalled)
-                {
-                    return PackageBase::IsSame(*otherInstalled);
-                }
-
-                return false;
-            }
-
-            const void* CastTo(IPackageType type) const override
-            {
-                if (type == PackageType)
-                {
-                    return this;
-                }
-
-                return nullptr;
-            }
+            mutable wil::srwlock m_versionKeysLock;
+            mutable std::vector<PackageVersionKey> m_versionKeys;
+            mutable std::map<MapKey, SQLiteIndex::IdType> m_versionKeysMap;
         };
     }
 
@@ -495,18 +429,9 @@ namespace AppInstaller::Repository::Microsoft
         std::shared_ptr<SQLiteIndexSource> sharedThis = NonConstSharedFromThis();
         for (auto& indexResult : indexResults.Matches)
         {
-            std::unique_ptr<IPackage> package;
-
-            if (m_isInstalled)
-            {
-                package = std::make_unique<InstalledPackage>(sharedThis, indexResult.first);
-            }
-            else
-            {
-                package = std::make_unique<AvailablePackage>(sharedThis, indexResult.first);
-            }
-
-            result.Matches.emplace_back(std::move(package), std::move(indexResult.second));
+            result.Matches.emplace_back(
+                std::make_shared<SQLitePackage>(sharedThis, indexResult.first, m_isInstalled),
+                std::move(indexResult.second));
         }
         result.Truncated = indexResults.Truncated;
         return result;

--- a/src/AppInstallerRepositoryCore/PackageInstalledStatus.cpp
+++ b/src/AppInstallerRepositoryCore/PackageInstalledStatus.cpp
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"
-#include "Public/winget/RepositorySearch.h"
+#include "Public/winget/InstalledStatus.h"
+#include "Public/winget/PackageVersionSelection.h"
 #include <winget/Filesystem.h>
 
 using namespace AppInstaller::Settings;
@@ -77,14 +78,14 @@ namespace AppInstaller::Repository
         }
 
         std::vector<InstallerInstalledStatus> CheckInstalledStatusInternal(
-            const std::shared_ptr<IPackage>& package,
+            const std::shared_ptr<ICompositePackage>& package,
             InstalledStatusType checkTypes)
         {
             using namespace AppInstaller::Manifest;
 
             std::vector<InstallerInstalledStatus> result;
             bool checkFileHash = false;
-            std::shared_ptr<IPackageVersion> installedVersion = package->GetInstalledVersion();
+            std::shared_ptr<IPackageVersion> installedVersion = package->GetInstalled()->GetLatestVersion();
             std::shared_ptr<IPackageVersion> availableVersion;
             FileHashMap fileHashes;
 
@@ -95,6 +96,8 @@ namespace AppInstaller::Repository
             std::string installedLocale;
             Utility::Architecture installedArchitecture = Utility::Architecture::Unknown;
             HRESULT installedLocationStatus = WINGET_INSTALLED_STATUS_INSTALL_LOCATION_NOT_APPLICABLE;
+
+            std::shared_ptr<IPackageVersionCollection> availableVersions = GetAvailableVersionsForInstalledVersion(package);
 
             // Prepare installed metadata from installed version.
             // Determine the available package version to be used for installed status checking.
@@ -120,14 +123,14 @@ namespace AppInstaller::Repository
                 {
                     // Use the base version as available version if installed version is mapped to be an approximate.
                     versionKey.Version = installedVersionAsVersion.GetBaseVersion().ToString();
-                    availableVersion = package->GetAvailableVersion(versionKey);
+                    availableVersion = availableVersions->GetVersion(versionKey);
                     // It's unexpected if the installed version is already mapped to some version.
                     THROW_HR_IF(E_UNEXPECTED, !availableVersion);
                 }
                 else
                 {
                     versionKey.Version = installedVersionAsVersion.ToString();
-                    availableVersion = package->GetAvailableVersion(versionKey);
+                    availableVersion = availableVersions->GetVersion(versionKey);
                     if (availableVersion)
                     {
                         checkFileHash = true;
@@ -139,7 +142,7 @@ namespace AppInstaller::Repository
             {
                 // No installed version, or installed version not found in available versions,
                 // then attempt to check installed status using latest version.
-                availableVersion = package->GetLatestAvailableVersion();
+                availableVersion = availableVersions->GetLatestVersion();
                 THROW_HR_IF(E_UNEXPECTED, !availableVersion);
             }
 
@@ -237,7 +240,7 @@ namespace AppInstaller::Repository
         }
     }
 
-    std::vector<InstallerInstalledStatus> CheckPackageInstalledStatus(const std::shared_ptr<IPackage>& package, InstalledStatusType checkTypes)
+    std::vector<InstallerInstalledStatus> CheckPackageInstalledStatus(const std::shared_ptr<ICompositePackage>& package, InstalledStatusType checkTypes)
     {
         return CheckInstalledStatusInternal(package, checkTypes);
     }

--- a/src/AppInstallerRepositoryCore/PackageInstalledStatus.cpp
+++ b/src/AppInstallerRepositoryCore/PackageInstalledStatus.cpp
@@ -85,7 +85,7 @@ namespace AppInstaller::Repository
 
             std::vector<InstallerInstalledStatus> result;
             bool checkFileHash = false;
-            std::shared_ptr<IPackageVersion> installedVersion = package->GetInstalled()->GetLatestVersion();
+            std::shared_ptr<IPackageVersion> installedVersion = GetInstalledVersion(package);
             std::shared_ptr<IPackageVersion> availableVersion;
             FileHashMap fileHashes;
 

--- a/src/AppInstallerRepositoryCore/PackageVersionSelection.cpp
+++ b/src/AppInstallerRepositoryCore/PackageVersionSelection.cpp
@@ -13,7 +13,7 @@ namespace AppInstaller::Repository
         {
             for (const std::shared_ptr<IPackage>& package : packages)
             {
-                if (sourceIdentifier != package->GetSource().GetIdentifier())
+                if (sourceIdentifier == package->GetSource().GetIdentifier())
                 {
                     return package;
                 }
@@ -34,9 +34,12 @@ namespace AppInstaller::Repository
 
                 m_channel = installedVersion->GetProperty(PackageVersionProperty::Channel);
 
-                // Remove the packages not from this source.
+                // Remove the packages that are not from the installed source.
                 Source installedVersionSource = installedVersion->GetSource();
-                m_packages.erase(std::remove_if(m_packages.begin(), m_packages.end(), [&](const std::shared_ptr<IPackage>& p) { return installedVersionSource != p->GetSource(); }), m_packages.end());
+                if (installedVersionSource && installedVersionSource.ContainsAvailablePackages())
+                {
+                    m_packages.erase(std::remove_if(m_packages.begin(), m_packages.end(), [&](const std::shared_ptr<IPackage>& p) { return installedVersionSource != p->GetSource(); }), m_packages.end());
+                }
             }
 
             std::vector<PackageVersionKey> GetVersionKeys() const override

--- a/src/AppInstallerRepositoryCore/PackageVersionSelection.cpp
+++ b/src/AppInstallerRepositoryCore/PackageVersionSelection.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "Public/winget/PackageVersionSelection.h"
+#include "Public/winget/RepositorySource.h"
+
+
+namespace AppInstaller::Repository
+{
+    namespace
+    {
+        struct AvailablePackageVersionCollection : public IPackageVersionCollection
+        {
+            AvailablePackageVersionCollection(const std::shared_ptr<ICompositePackage>& composite) :
+                m_packages(composite->GetAvailable())
+            {
+                std::shared_ptr<IPackage> installed = composite->GetInstalled();
+                if (!installed)
+                {
+                    return;
+                }
+
+                std::shared_ptr<IPackageVersion> installedVersion = installed->GetLatestVersion();
+                if (!installedVersion)
+                {
+                    return;
+                }
+
+                m_channel = installedVersion->GetProperty(PackageVersionProperty::Channel);
+
+                // Remove the packages not from this source.
+                Source installedVersionSource = installedVersion->GetSource();
+                m_packages.erase(std::remove_if(m_packages.begin(), m_packages.end(), [&](const std::shared_ptr<IPackage>& p) { return installedVersionSource != p->GetSource(); }), m_packages.end());
+            }
+
+            std::vector<PackageVersionKey> GetVersionKeys() const override
+            {
+                std::vector<PackageVersionKey> result;
+
+                for (const std::shared_ptr<IPackage>& package : m_packages)
+                {
+                    std::vector<PackageVersionKey> versionKeys = package->GetVersionKeys();
+                    std::copy(versionKeys.begin(), versionKeys.end(), std::back_inserter(result));
+                }
+
+                // Remove all elements whose channel does not match the installed package.
+                std::string_view channel = m_channel;
+                result.erase(
+                    std::remove_if(result.begin(), result.end(), [&](const PackageVersionKey& pvk) { return !Utility::ICUCaseInsensitiveEquals(pvk.Channel, channel); }),
+                    result.end());
+
+                return result;
+            }
+
+            std::shared_ptr<IPackageVersion> GetVersion(const PackageVersionKey& versionKey) const override
+            {
+                for (const std::shared_ptr<IPackage>& package : m_packages)
+                {
+                    if (!Utility::IsEmptyOrWhitespace(versionKey.SourceId))
+                    {
+                        if (versionKey.SourceId != package->GetSource().GetIdentifier())
+                        {
+                            continue;
+                        }
+                    }
+
+                    return package->GetVersion(versionKey);
+                }
+
+                return {};
+            }
+
+            std::shared_ptr<IPackageVersion> GetLatestVersion() const override
+            {
+                return GetVersion({ "", "", m_channel });
+            }
+
+        private:
+            std::string m_channel;
+            std::vector<std::shared_ptr<IPackage>> m_packages;
+        };
+    }
+
+    std::shared_ptr<IPackageVersionCollection> GetAvailableVersionsForInstalledVersion(const std::shared_ptr<ICompositePackage>& composite)
+    {
+        return std::make_shared<AvailablePackageVersionCollection>(composite);
+    }
+}

--- a/src/AppInstallerRepositoryCore/PackageVersionSelection.cpp
+++ b/src/AppInstallerRepositoryCore/PackageVersionSelection.cpp
@@ -11,16 +11,9 @@ namespace AppInstaller::Repository
     {
         struct AvailablePackageVersionCollection : public IPackageVersionCollection
         {
-            AvailablePackageVersionCollection(const std::shared_ptr<ICompositePackage>& composite) :
+            AvailablePackageVersionCollection(const std::shared_ptr<ICompositePackage>& composite, const std::shared_ptr<IPackageVersion>& installedVersion) :
                 m_packages(composite->GetAvailable())
             {
-                std::shared_ptr<IPackage> installed = composite->GetInstalled();
-                if (!installed)
-                {
-                    return;
-                }
-
-                std::shared_ptr<IPackageVersion> installedVersion = installed->GetLatestVersion();
                 if (!installedVersion)
                 {
                     return;
@@ -83,6 +76,32 @@ namespace AppInstaller::Repository
 
     std::shared_ptr<IPackageVersionCollection> GetAvailableVersionsForInstalledVersion(const std::shared_ptr<ICompositePackage>& composite)
     {
-        return std::make_shared<AvailablePackageVersionCollection>(composite);
+        return std::make_shared<AvailablePackageVersionCollection>(composite, GetInstalledVersion(composite));
+    }
+
+    std::shared_ptr<IPackageVersionCollection> GetAvailableVersionsForInstalledVersion(
+        const std::shared_ptr<ICompositePackage>& composite,
+        const std::shared_ptr<IPackageVersion>& installedVersion)
+    {
+        return std::make_shared<AvailablePackageVersionCollection>(composite, installedVersion);
+    }
+
+    std::shared_ptr<IPackageVersion> GetInstalledVersion(const std::shared_ptr<ICompositePackage>& composite)
+    {
+        auto installedPackage = composite->GetInstalled();
+        return installedPackage ? installedPackage->GetLatestVersion() : nullptr;
+    }
+
+    std::shared_ptr<IPackage> GetAvailablePackageFromSource(const std::shared_ptr<ICompositePackage>& composite, const std::string_view sourceIdentifier)
+    {
+        for (const std::shared_ptr<IPackage>& package : composite->GetAvailable())
+        {
+            if (sourceIdentifier != package->GetSource().GetIdentifier())
+            {
+                return package;
+            }
+        }
+
+        return {};
     }
 }

--- a/src/AppInstallerRepositoryCore/PinningData.cpp
+++ b/src/AppInstallerRepositoryCore/PinningData.cpp
@@ -145,19 +145,19 @@ namespace AppInstaller::Pinning
 
     PinningData::PinStateEvaluator::~PinStateEvaluator() = default;
 
-    std::shared_ptr<IPackageVersion> PinningData::PinStateEvaluator::GetLatestAvailableVersionForPins(const std::shared_ptr<IPackage>& package)
+    std::shared_ptr<IPackageVersion> PinningData::PinStateEvaluator::GetLatestAvailableVersionForPins(const std::shared_ptr<IPackageVersionCollection>& package)
     {
         if (!m_database)
         {
-            return package->GetLatestAvailableVersion();
+            return package->GetLatestVersion();
         }
 
-        auto availableVersionKeys = package->GetAvailableVersionKeys();
+        auto availableVersionKeys = package->GetVersionKeys();
 
         // Skip until we find a version that isn't pinned
         for (const auto& availableVersion : availableVersionKeys)
         {
-            std::shared_ptr<IPackageVersion> packageVersion = package->GetAvailableVersion(availableVersion);
+            std::shared_ptr<IPackageVersion> packageVersion = package->GetVersion(availableVersion);
             if (EvaluatePinType(packageVersion) == Pinning::PinType::Unknown)
             {
                 return packageVersion;

--- a/src/AppInstallerRepositoryCore/Public/winget/InstalledStatus.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/InstalledStatus.h
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include <AppInstallerStrings.h>
+#include <winget/Manifest.h>
+#include <winget/RepositorySearch.h>
+
+#include <memory>
+#include <vector>
+
+
+namespace AppInstaller::Repository
+{
+    // Defines the installed status check type.
+    enum class InstalledStatusType : uint32_t
+    {
+        // None is checked.
+        None = 0x0,
+        // Check Apps and Features entry.
+        AppsAndFeaturesEntry = 0x0001,
+        // Check Apps and Features entry install location if applicable.
+        AppsAndFeaturesEntryInstallLocation = 0x0002,
+        // Check Apps and Features entry install location with installed files if applicable.
+        AppsAndFeaturesEntryInstallLocationFile = 0x0004,
+        // Check default install location if applicable.
+        DefaultInstallLocation = 0x0008,
+        // Check default install location with installed files if applicable.
+        DefaultInstallLocationFile = 0x0010,
+
+        // Below are helper values for calling CheckInstalledStatus as input.
+        // AppsAndFeaturesEntry related checks
+        AllAppsAndFeaturesEntryChecks = AppsAndFeaturesEntry | AppsAndFeaturesEntryInstallLocation | AppsAndFeaturesEntryInstallLocationFile,
+        // DefaultInstallLocation related checks
+        AllDefaultInstallLocationChecks = DefaultInstallLocation | DefaultInstallLocationFile,
+        // All checks
+        AllChecks = AllAppsAndFeaturesEntryChecks | AllDefaultInstallLocationChecks,
+    };
+
+    DEFINE_ENUM_FLAG_OPERATORS(InstalledStatusType);
+
+    // Struct representing an individual installed status.
+    struct InstalledStatus
+    {
+        // The installed status type.
+        InstalledStatusType Type = InstalledStatusType::None;
+        // The installed status path.
+        Utility::NormalizedString Path;
+        // The installed status result.
+        HRESULT Status;
+
+        InstalledStatus(InstalledStatusType type, Utility::NormalizedString path, HRESULT status) :
+            Type(type), Path(std::move(path)), Status(status) {}
+    };
+
+    // Struct representing installed status from an installer.
+    struct InstallerInstalledStatus
+    {
+        Manifest::ManifestInstaller Installer;
+        std::vector<InstalledStatus> Status;
+    };
+
+    // Checks installed status of a package.
+    std::vector<InstallerInstalledStatus> CheckPackageInstalledStatus(const std::shared_ptr<ICompositePackage>& package, InstalledStatusType checkTypes = InstalledStatusType::AllChecks);
+}

--- a/src/AppInstallerRepositoryCore/Public/winget/PackageVersionSelection.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/PackageVersionSelection.h
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include <winget/RepositorySearch.h>
+
+
+namespace AppInstaller::Repository
+{
+    // Gets an IPackage that represents the available package versions for the installed version..
+    std::shared_ptr<IPackageVersionCollection> GetAvailableVersionsForInstalledVersion(const std::shared_ptr<ICompositePackage>& composite);
+}

--- a/src/AppInstallerRepositoryCore/Public/winget/PackageVersionSelection.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/PackageVersionSelection.h
@@ -6,6 +6,18 @@
 
 namespace AppInstaller::Repository
 {
-    // Gets an IPackage that represents the available package versions for the installed version..
+    // Gets an IPackage that represents the available package versions for the installed version.
+    // This function uses the latest installed version as a temporary convenience until side-by-side is implemented.
     std::shared_ptr<IPackageVersionCollection> GetAvailableVersionsForInstalledVersion(const std::shared_ptr<ICompositePackage>& composite);
+
+    // Gets an IPackage that represents the available package versions for the given installed version.
+    std::shared_ptr<IPackageVersionCollection> GetAvailableVersionsForInstalledVersion(
+        const std::shared_ptr<ICompositePackage>& composite,
+        const std::shared_ptr<IPackageVersion>& installedVersion);
+
+    // Gets the installed version, or a null if there isn't one.
+    std::shared_ptr<IPackageVersion> GetInstalledVersion(const std::shared_ptr<ICompositePackage>& composite);
+
+    // Gets the available IPackage corresponding to the given source identifier.
+    std::shared_ptr<IPackage> GetAvailablePackageFromSource(const std::shared_ptr<ICompositePackage>& composite, const std::string_view sourceIdentifier);
 }

--- a/src/AppInstallerRepositoryCore/Public/winget/PackageVersionSelection.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/PackageVersionSelection.h
@@ -6,11 +6,12 @@
 
 namespace AppInstaller::Repository
 {
-    // Gets an IPackage that represents the available package versions for the installed version.
+    // Gets an IPackageVersionCollection that represents the available package versions for the installed version.
+    // If we have tracking data, will remove packages not from the tracked source. Will also remove versions that do not correspond to the tracked channel.
     // This function uses the latest installed version as a temporary convenience until side-by-side is implemented.
     std::shared_ptr<IPackageVersionCollection> GetAvailableVersionsForInstalledVersion(const std::shared_ptr<ICompositePackage>& composite);
 
-    // Gets an IPackage that represents the available package versions for the given installed version.
+    // Gets an IPackageVersionCollection that represents the available package versions for the given installed version.
     std::shared_ptr<IPackageVersionCollection> GetAvailableVersionsForInstalledVersion(
         const std::shared_ptr<ICompositePackage>& composite,
         const std::shared_ptr<IPackageVersion>& installedVersion);

--- a/src/AppInstallerRepositoryCore/Public/winget/PinningData.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/PinningData.h
@@ -79,7 +79,7 @@ namespace AppInstaller::Pinning
 
             // Gets the latest available package version that fits within the pinning restrictions.
             // This should be the package object that contains available versions associated with the installed version for which this evaluator was created.
-            std::shared_ptr<AppInstaller::Repository::IPackageVersion> GetLatestAvailableVersionForPins(const std::shared_ptr<AppInstaller::Repository::IPackage>& package);
+            std::shared_ptr<AppInstaller::Repository::IPackageVersion> GetLatestAvailableVersionForPins(const std::shared_ptr<AppInstaller::Repository::IPackageVersionCollection>& package);
 
             // Determines if the given version is an update to the installed version that this object was created with.
             // This should be a version associated with the installed version for which this evaluator was created.

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySearch.h
@@ -254,6 +254,10 @@ namespace AppInstaller::Repository
             // The order for the sources depends on the context.
             return Utility::VersionAndChannel({ Version }, { Channel }) < Utility::VersionAndChannel({ other.Version }, { other.Channel });
         }
+
+        // Determines if a well defined key (this one) is matched by the provided key.
+        // The provided key may use empty values to indicate no specific matching requirements.
+        bool IsMatch(const PackageVersionKey& other) const;
     };
 
 
@@ -316,11 +320,10 @@ namespace AppInstaller::Repository
     enum class IPackageType
     {
         TestPackage,
-        RestAvailablePackage,
-        SQLiteAvailablePackage,
-        SQLiteInstalledPackage,
+        RestPackage,
+        SQLitePackage,
         PinnablePackage,
-        CompositePackage,
+        CompositeInstalledPackage,
     };
 
     // Contains information about a package and its versions from a single source.
@@ -352,20 +355,20 @@ namespace AppInstaller::Repository
         virtual const void* CastTo(IPackageType type) const = 0;
     };
 
-    // Contains information about a package from a search result.
-    struct IPackageSearchResult
+    // Contains information about the graph of packages related to a search.
+    struct ICompositePackage
     {
-        virtual ~IPackageSearchResult() = default;
+        virtual ~ICompositePackage() = default;
 
         // Gets a property of this package result.
         virtual Utility::LocIndString GetProperty(PackageProperty property) const = 0;
 
         // Gets the installed package information.
-        virtual std::shared_ptr<IPackage> GetInstalled() const = 0;
+        virtual std::shared_ptr<IPackage> GetInstalled() = 0;
 
         // Gets all of the available packages for this result.
         // There will be at most one package per source in this list.
-        virtual std::vector<std::shared_ptr<IPackage>> GetAvailable() const = 0;
+        virtual std::vector<std::shared_ptr<IPackage>> GetAvailable() = 0;
     };
 
     // Does the equivalent of a dynamic_cast, but without it to allow RTTI to be disabled.
@@ -391,12 +394,12 @@ namespace AppInstaller::Repository
     struct ResultMatch
     {
         // The package found by the search request.
-        std::shared_ptr<IPackageSearchResult> Package;
+        std::shared_ptr<ICompositePackage> Package;
 
         // The highest order field on which the package matched the search.
         PackageMatchFilter MatchCriteria;
 
-        ResultMatch(std::shared_ptr<IPackageSearchResult> p, PackageMatchFilter f) : Package(std::move(p)), MatchCriteria(std::move(f)) {}
+        ResultMatch(std::shared_ptr<ICompositePackage> p, PackageMatchFilter f) : Package(std::move(p)), MatchCriteria(std::move(f)) {}
     };
 
     // Search result data.

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
@@ -220,6 +220,11 @@ namespace AppInstaller::Repository
         // To avoid putting try catch everywhere, we use bool operator here.
         operator bool() const;
 
+        // Determines if the sources are equivalent.
+        // Currently only works for individual sources, not composites.
+        bool operator==(const Source& other) const;
+        bool operator!=(const Source& other) const;
+
         // Gets the source's identifier; a unique identifier independent of the name
         // that will not change between a remove/add or between additional adds.
         // Must be suitable for filesystem names unless the source is internal to winget,

--- a/src/AppInstallerRepositoryCore/RepositorySearch.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySearch.cpp
@@ -92,6 +92,14 @@ namespace AppInstaller::Repository
         }
     }
 
+    bool PackageVersionKey::IsMatch(const PackageVersionKey& other) const
+    {
+        return
+            ((other.SourceId.empty() || other.SourceId == SourceId) &&
+             (other.Version.empty() || Utility::ICUCaseInsensitiveEquals(other.Version, Version)) &&
+             (other.Channel.empty() || Utility::ICUCaseInsensitiveEquals(other.Channel, Channel)));
+    }
+
     const char* UnsupportedRequestException::what() const noexcept
     {
         if (m_whatMessage.empty())

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -473,6 +473,19 @@ namespace AppInstaller::Repository
         }
     }
 
+    bool Source::operator==(const Source& other) const
+    {
+        SourceDetails thisDetails = GetDetails();
+        SourceDetails otherDetails = other.GetDetails();
+
+        return (thisDetails.Type == otherDetails.Type && thisDetails.Identifier == otherDetails.Identifier);
+    }
+
+    bool Source::operator!=(const Source& other) const
+    {
+        return !operator==(other);
+    }
+
     std::string Source::GetIdentifier() const
     {
         if (m_source)

--- a/src/AppInstallerRepositoryCore/Rest/RestSource.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSource.cpp
@@ -461,7 +461,7 @@ namespace AppInstaller::Repository::Rest
         std::shared_ptr<RestSource> sharedThis = NonConstSharedFromThis();
         for (auto& result : results.Matches)
         {
-            std::shared_ptr<IPackage> package = std::make_shared<RestPackage>(sharedThis, std::move(result));
+            std::shared_ptr<ICompositePackage> package = std::make_shared<RestPackage>(sharedThis, std::move(result));
 
             // TODO: Improve to use Package match filter to return relevant search results.
             PackageMatchFilter packageFilter{ {}, {}, {} };

--- a/src/AppInstallerSharedLib/Yaml.cpp
+++ b/src/AppInstallerSharedLib/Yaml.cpp
@@ -407,14 +407,17 @@ namespace AppInstaller::YAML
 
     std::optional<int64_t> Node::try_as_dispatch(int64_t*) const
     {
-        try
-        {
-            return std::optional{ std::stoll(m_scalar) };
-        }
-        catch(...)
+        const char* begin = m_scalar.c_str();
+        char* end = nullptr;
+        errno = 0;
+        int64_t result = static_cast<int64_t>(strtoll(begin, &end, 0));
+
+        if (errno == ERANGE || static_cast<size_t>(end - begin) != m_scalar.length())
         {
             return {};
         }
+
+        return result;
     }
 
     int Node::as_dispatch(int*) const

--- a/src/Microsoft.Management.Deployment/CatalogPackage.cpp
+++ b/src/Microsoft.Management.Deployment/CatalogPackage.cpp
@@ -12,13 +12,14 @@
 #include "CheckInstalledStatusResult.h"
 #include <wil\cppwinrt_wrl.h>
 #include <winget/PinningData.h>
+#include <winget/PackageVersionSelection.h>
 
 
 namespace winrt::Microsoft::Management::Deployment::implementation
 {
     void CatalogPackage::Initialize(
         ::AppInstaller::Repository::Source source,
-        std::shared_ptr<::AppInstaller::Repository::IPackage> package)
+        std::shared_ptr<::AppInstaller::Repository::ICompositePackage> package)
     {
         m_source = std::move(source);
         m_package = std::move(package);
@@ -36,7 +37,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         std::call_once(m_installedVersionOnceFlag,
             [&]()
             {
-                std::shared_ptr<::AppInstaller::Repository::IPackageVersion> installedVersion = m_package.get()->GetInstalledVersion();
+                std::shared_ptr<::AppInstaller::Repository::IPackageVersion> installedVersion = GetInstalledVersion(m_package);
                 if (installedVersion)
                 {
                     auto installedVersionImpl = winrt::make_self<wil::details::module_count_wrapper<
@@ -53,7 +54,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             [&]()
             {
                 // Vector hasn't been populated yet.
-                for (auto const& versionKey : m_package.get()->GetAvailableVersionKeys())
+                for (auto const& versionKey : ::AppInstaller::Repository::GetAvailableVersionsForInstalledVersion(m_package, nullptr)->GetVersionKeys())
                 {
                     auto packageVersionId = winrt::make_self<wil::details::module_count_wrapper<
                         winrt::Microsoft::Management::Deployment::implementation::PackageVersionId>>();
@@ -72,9 +73,10 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                 using namespace AppInstaller::Pinning;
 
                 PinningData pinningData{ PinningData::Disposition::ReadOnly };
-                auto evaluator = pinningData.CreatePinStateEvaluator(PinBehavior::ConsiderPins, m_package->GetInstalledVersion());
+                auto evaluator = pinningData.CreatePinStateEvaluator(PinBehavior::ConsiderPins, GetInstalledVersion(m_package));
 
-                std::shared_ptr<::AppInstaller::Repository::IPackageVersion> latestVersion = evaluator.GetLatestAvailableVersionForPins(m_package);
+                std::shared_ptr<::AppInstaller::Repository::IPackageVersion> latestVersion =
+                    evaluator.GetLatestAvailableVersionForPins(::AppInstaller::Repository::GetAvailableVersionsForInstalledVersion(m_package));
                 if (latestVersion)
                 {
                     m_updateAvailable = evaluator.IsUpdate(latestVersion);
@@ -100,7 +102,8 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         winrt::Microsoft::Management::Deployment::PackageVersionInfo packageVersionInfo{ nullptr };
 
         ::AppInstaller::Repository::PackageVersionKey internalVersionKey(winrt::to_string(versionKey.PackageCatalogId()), winrt::to_string(versionKey.Version()), winrt::to_string(versionKey.Channel()));
-        std::shared_ptr<::AppInstaller::Repository::IPackageVersion> availableVersion = m_package.get()->GetAvailableVersion(internalVersionKey);
+        std::shared_ptr<::AppInstaller::Repository::IPackageVersion> availableVersion =
+            ::AppInstaller::Repository::GetAvailableVersionsForInstalledVersion(m_package, nullptr)->GetVersion(internalVersionKey);
         if (availableVersion)
         {
             auto packageVersionInfoImpl = winrt::make_self<wil::details::module_count_wrapper<
@@ -161,7 +164,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     {
         return CheckInstalledStatus(InstalledStatusType::AllChecks);
     }
-    std::shared_ptr<::AppInstaller::Repository::IPackage> CatalogPackage::GetRepositoryPackage()
+    std::shared_ptr<::AppInstaller::Repository::ICompositePackage> CatalogPackage::GetRepositoryPackage()
     {
         return m_package;
     }

--- a/src/Microsoft.Management.Deployment/CatalogPackage.h
+++ b/src/Microsoft.Management.Deployment/CatalogPackage.h
@@ -12,8 +12,8 @@ namespace winrt::Microsoft::Management::Deployment::implementation
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
         void Initialize(
             ::AppInstaller::Repository::Source source,
-            std::shared_ptr<::AppInstaller::Repository::IPackage> package);
-        std::shared_ptr<::AppInstaller::Repository::IPackage> GetRepositoryPackage();
+            std::shared_ptr<::AppInstaller::Repository::ICompositePackage> package);
+        std::shared_ptr<::AppInstaller::Repository::ICompositePackage> GetRepositoryPackage();
 #endif
 
         hstring Id();
@@ -34,7 +34,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:
         ::AppInstaller::Repository::Source m_source;
-        std::shared_ptr<::AppInstaller::Repository::IPackage> m_package;
+        std::shared_ptr<::AppInstaller::Repository::ICompositePackage> m_package;
         bool m_updateAvailable = false;
         Windows::Foundation::Collections::IVector<winrt::Microsoft::Management::Deployment::PackageVersionId> m_availableVersions{ winrt::single_threaded_vector<winrt::Microsoft::Management::Deployment::PackageVersionId>() };
         winrt::Microsoft::Management::Deployment::PackageVersionInfo m_installedVersion{ nullptr };

--- a/src/Microsoft.Management.Deployment/InstalledStatus.h
+++ b/src/Microsoft.Management.Deployment/InstalledStatus.h
@@ -3,6 +3,7 @@
 #pragma once
 #include "InstalledStatus.g.h"
 #include <winget/RepositorySearch.h>
+#include <winget/InstalledStatus.h>
 
 namespace winrt::Microsoft::Management::Deployment::implementation
 {

--- a/src/Microsoft.Management.Deployment/PackageInstallerInstalledStatus.h
+++ b/src/Microsoft.Management.Deployment/PackageInstallerInstalledStatus.h
@@ -3,6 +3,7 @@
 #pragma once
 #include "PackageInstallerInstalledStatus.g.h"
 #include <winget/RepositorySearch.h>
+#include <winget/InstalledStatus.h>
 #include <winrt/Windows.Foundation.Collections.h>
 
 namespace winrt::Microsoft::Management::Deployment::implementation

--- a/src/Microsoft.Management.Deployment/PackageManager.cpp
+++ b/src/Microsoft.Management.Deployment/PackageManager.cpp
@@ -676,7 +676,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
 
         // Add Package which is used by RecordUninstall later for removing from tracking catalog of correlated available sources as best effort
         winrt::Microsoft::Management::Deployment::implementation::CatalogPackage* catalogPackageImpl = get_self<winrt::Microsoft::Management::Deployment::implementation::CatalogPackage>(package);
-        std::shared_ptr<::AppInstaller::Repository::IPackage> internalPackage = catalogPackageImpl->GetRepositoryPackage();
+        std::shared_ptr<::AppInstaller::Repository::ICompositePackage> internalPackage = catalogPackageImpl->GetRepositoryPackage();
         comContext->Add<AppInstaller::CLI::Execution::Data::Package>(internalPackage);
 
         return Execution::OrchestratorQueueItemFactory::CreateItemForUninstall(std::wstring{ package.Id() }, std::wstring{ package.InstalledVersion().PackageCatalog().Info().Id() }, std::move(comContext));


### PR DESCRIPTION
The goal of this change is to create a better model of what is actually happening with correlation so that we can move business logic out of CompositeSource (much like moving the pinning out).  It enables callers to see:
1. Multiple installed versions
2. The packages from sources rather than just a jumble of versions

This in turn forces business logic decisions on the caller that were being made internally (merging available versions across sources for instance).  Ultimately, the goal would be that the version choice is completely independent of the search.  Even if that thing is a semi-monolithic decision engine, it will be more easily directed and won't be tied into the correlation code.

Please weigh in on this first order change.  The future PR will be all of the required fallout from this, minus the side-by-side support (all usage of `GetInstalledVersion()` would just become `GetInstalled()->GetLatestVersion()`).